### PR TITLE
chore: switch to bsd3 license

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,7 @@ name: PR
 on: pull_request
 
 env:
-  # Run all cargo commands with --verbose.
-  CARGO_TERM_VERBOSE: true
   RUST_BACKTRACE: 1
-  # Deny all compiler warnings.
   RUSTFLAGS: "-D warnings"
 
 jobs:
@@ -30,7 +27,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -40,26 +36,20 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # Check if the code is formatted correctly.
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      # Run Clippy.
       - name: Clippy checks
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features -- -Dwarnings
 
-  check_pr_size:
-    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
-    name: Check PR size doesn't break set limit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - name: install rg for licensing verification
+        run: cargo install ripgrep
+
+      - uses: maidsafe/verify-licensing-info@main
+        name: verify licensing
         with:
-          fetch-depth: '0'
-      - uses: maidsafe/pr_size_checker@v2
-        with:
-          max_lines_changed: 200
-  
+          company-name: MaidSafe
+
   coverage:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Code coverage check
@@ -67,14 +57,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -84,7 +72,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # Run cargo tarpaulin & push result to coveralls.io
       - name: rust-tarpaulin code coverage check
         uses: actions-rs/tarpaulin@v0.1
         with:
@@ -117,7 +104,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -127,7 +113,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # Make sure the code builds.
       - name: Run cargo build
         run: cargo build --release
 
@@ -147,7 +132,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -157,7 +141,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # Run the tests
       - name: Run cargo test
         run: cargo test --release
   
@@ -167,7 +150,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -185,13 +167,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # wget the shared deny.toml file from the QA repo
     - shell: bash
       run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
 
     - uses: EmbarkStudios/cargo-deny-action@v1
   
-  # Test publish using --dry-run.
   test-publish:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Test Publish


### PR DESCRIPTION
Currently this repository is dual license BSD/MIT. We decided our licensing policy would be to use BSD-3-Clause for all crates without the `sn_` prefix, which will use GPL3.

To achieve this:
* The `verify-licensing-info` custom action is applied to make sure licensing is applied consistently.